### PR TITLE
Cross-compile libopus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ license = "Apache-2.0"
 
 [dependencies]
 
+[build-dependencies]
+cc = "1.0"
+
 [build-dependencies.bindgen]
 version = "0.43"
 optional = true


### PR DESCRIPTION
I was unable to cross-compile this crate.  I fixed this by checking
what cross-compiling configure options and environment variables
libsodium-sys sets, since that was a crate I had on hand that did
cross-compile.

This patch sets CC, CFLAGS, and --host to their appropriate values.
CFLAGS is set conditionally if it isn't empty, because otherwise it'll
[clobber](https://github.com/maidsafe/rust_sodium/pull/54) default CFLAGS like -O2.