### PR TITLE
Disable presume features to let opus to perform runtime check for HW

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -54,27 +54,11 @@ fn build() {
 
     if host == target {
         if !std::is_x86_feature_detected!("avx") {
-            cmake.define("OPUS_X86_MAY_HAVE_AVX", "OFF")
-                 .define("OPUS_X86_PRESUME_AVX", "OFF")
-                 .define("AVX_SUPPORTED", "OFF");
+            cmake.define("OPUS_X86_PRESUME_AVX", "OFF");
         }
 
         if !std::is_x86_feature_detected!("sse4.1") {
-            cmake.define("OPUS_X86_MAY_HAVE_SSE4_1", "OFF")
-                 .define("OPUS_X86_PRESUME_SSE4_1", "OFF")
-                 .define("SSE4_1_SUPPORTED", "OFF");
-        }
-
-        if !std::is_x86_feature_detected!("sse2") {
-            cmake.define("OPUS_X86_MAY_HAVE_SSE2", "OFF")
-                 .define("OPUS_X86_PRESUME_SSE2", "OFF")
-                 .define("SSE2_SUPPORTED", "OFF");
-        }
-
-        if !std::is_x86_feature_detected!("sse") {
-            cmake.define("OPUS_X86_MAY_HAVE_SSE", "OFF")
-                 .define("OPUS_X86_PRESUME_SSE", "OFF")
-                 .define("SSE1_SUPPORTED", "OFF");
+            cmake.define("OPUS_X86_PRESUME_SSE4_1", "OFF");
         }
     }
 


### PR DESCRIPTION
@DuckerMan

We need to hack around opus defined to make sure that it performs runtime check for option.
I think attempting to disable SSE4.1 and AVX completely will be impossible because of the way opus checks for its availability