### PR TITLE
Rename `Intsafe.h` to `intsafe.h` for case-sensitive OS

### DIFF
--- a/opus/silk/x86/NSQ_del_dec_avx2.c
+++ b/opus/silk/x86/NSQ_del_dec_avx2.c
@@ -72,7 +72,7 @@ static OPUS_INLINE int verify_assumptions(const silk_encoder_state *psEncC)
 
 /* Intrinsics not defined on MSVC */
 #ifdef _MSC_VER
-#include <Intsafe.h>
+#include <intsafe.h>
 static inline int __builtin_sadd_overflow(opus_int32 a, opus_int32 b, opus_int32* res)
 {
     *res = a+b;


### PR DESCRIPTION
The changes in this PR have already been added to the Opus codebase but have not yet been released. As someone trying to cross-compile from Linux to Windows, this change is crucial for me. Since it's just a minor typo fix, I would appreciate it if you could accept this PR so that I can use the changes before Opus releases a new version.

The merged PR in Opus: https://github.com/xiph/opus/pull/365