### PR TITLE
set(CMAKE_TRY_COMPILE_TARGET_TYPE, STATIC_LIBRARY)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -93,7 +93,8 @@ fn build() {
          .define("CMAKE_INSTALL_MANDIR", "man")
          .define("CMAKE_INSTALL_INCLUDEDIR", "include")
          .define("CMAKE_INSTALL_OLDINCLUDEDIR", "include")
-         .define("CMAKE_INSTALL_LIBDIR", "lib");
+         .define("CMAKE_INSTALL_LIBDIR", "lib")
+         .define("CMAKE_TRY_COMPILE_TARGET_TYPE", "STATIC_LIBRARY");
 
     if let Some((toolchain_file, abi)) = get_android_vars() {
         cmake.define("CMAKE_TOOLCHAIN_FILE", toolchain_file);


### PR DESCRIPTION
CMake test compiler by building simple project, and the default is executable.

Our case, we use wasi-clang, which doesn't support building executable, but only static library.

opusic is the opus porting project, which is not executable, but the library. so I hope this crate set CMAKE_TRY_COMPILE_TARGET_TYPE as STATIC_LIBRARY to pass executable building test.