### PR TITLE
build: force `-fno-lto` for the bundled libopus build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,7 @@ on:
       - 'src/**.rs'
       - 'tests/**'
       - 'Cargo.toml'
+      - 'build.rs'
       - 'opus/**/*'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -19,6 +20,7 @@ on:
       - 'src/**.rs'
       - 'tests/**'
       - 'Cargo.toml'
+      - 'build.rs'
       - 'opus/**/*'
 jobs:
   check:

--- a/build.rs
+++ b/build.rs
@@ -100,7 +100,19 @@ fn build() {
          .define("CMAKE_INSTALL_INCLUDEDIR", "include")
          .define("CMAKE_INSTALL_OLDINCLUDEDIR", "include")
          .define("CMAKE_INSTALL_LIBDIR", "lib")
-         .define("CMAKE_TRY_COMPILE_TARGET_TYPE", "STATIC_LIBRARY");
+         .define("CMAKE_TRY_COMPILE_TARGET_TYPE", "STATIC_LIBRARY")
+         // The bundled libopus.a is consumed by rustc (bundled into the
+         // rlib), not the C link, so C-level LTO gains nothing here. If the
+         // ambient CFLAGS contain `-flto` (e.g. Arch's makepkg with
+         // `OPTIONS=(lto)`, Gentoo `LTOFLAGS`, distros enabling it by
+         // default), GCC produces slim LTO objects: empty `.text`, code only
+         // in `.gnu.lto_*` sections, marked with `__gnu_lto_slim`. rust-lld
+         // links the rlib without an LTO plugin and reports the opus_*
+         // symbols as undefined. Force LTO off here regardless of inherited
+         // flags. `-fno-lto` overrides any preceding `-flto*` (gcc/clang
+         // honor the last one) and is a no-op for compilers that don't
+         // recognize it.
+         .cflag("-fno-lto");
 
     //Keep this up to date with Cargo.toml
     if cfg!(feature = "dred") {


### PR DESCRIPTION
## Summary

When `opusic-sys` is built with the `bundled` feature (default) and the
ambient `CFLAGS` contain `-flto*` — common on distros that enable LTO by
default for package builds, e.g. Arch's `makepkg` with `OPTIONS=(lto)`
appending `LTOFLAGS="-flto=auto"`, Gentoo's `LTOFLAGS`, etc. — the
final link of any binary that pulls `opusic-sys` transitively fails
with:

```
rust-lld: error: undefined symbol: opus_decoder_destroy
rust-lld: error: undefined symbol: opus_decode
rust-lld: error: undefined symbol: opus_decoder_create
```

even though `libopus.a` is built and bundled into `libopusic_sys.rlib`.

## Root cause

With `-flto` in `CFLAGS`, GCC produces *slim LTO* objects when
compiling the libopus sources:

- `.text` is empty (size 0).
- The actual code lives in `.gnu.lto_*` sections.
- Each object carries a `__gnu_lto_slim` marker.

rustc bundles those `.o` files into the rlib (cargo's default `+bundle`
modifier on `cargo:rustc-link-lib=static=opus`). When a downstream
binary links, rust-lld processes the rlib without an LTO plugin loaded,
sees no native code in `.text`, and the symbols look undefined.

`readelf -SW opus_decoder.c.o` on a failing build:
```
[ 1] .text             PROGBITS … size 000000      <- empty
[ 4] .gnu.lto_.profile PROGBITS …
[ 5] .gnu.lto_.icf     PROGBITS …
…
.symtab: __gnu_lto_slim    OBJECT GLOBAL DEFAULT COM
```

The bundled `libopus.a` is consumed by rustc, not a C linker, so doing
LTO at the C level gains nothing in this build path — it only ever
breaks it.

## Fix

Append `-fno-lto` to the cmake C flags. gcc/clang honor the last
`-flto*` argument on the command line, so this overrides any inherited
`-flto`. It is a no-op for compilers that don't recognize it.

After the fix, `opus_decoder.c.o` has real native code in
`.text.opus_decoder_create` and the link succeeds.

## Reproducer

On Arch (or any host with `-flto*` in `CFLAGS`), build any crate that
links opusic-sys transitively (e.g. `symphonia-adapter-libopus`):

```sh
LDFLAGS="-Wl,-O1 -Wl,--as-needed -Wl,-z,relro -Wl,-z,now" \
CFLAGS="-O3 -fno-plt -flto=auto" \
cargo build --release
```

Without this patch: `rust-lld: error: undefined symbol: opus_decoder_*`.
With this patch: links cleanly. Verified locally against
`kopuz` (uses `symphonia-adapter-libopus → opusic-sys`) on
`rustc 1.95.0` with rust-lld.

## Test plan
- [x] Build fails on Arch with `OPTIONS=(lto)` before the patch (reproduced)
- [x] Build succeeds on Arch with `OPTIONS=(lto)` after the patch (verified end-to-end binary contains `opus_decoder_create`)
- [x] `readelf` confirms post-fix `.o` files are normal ELF, no `.gnu.lto_*` sections, no `__gnu_lto_slim` marker
- [ ] CI: existing `tests/version.rs` should still pass (compiler had no `-flto` in its baseline CFLAGS, so no behavioral change expected)