### PR TITLE
Fix rustfmt on bindings, enable cross-language LTO, and improve Opus build configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,5 @@ no-simd = []
 fixed-point = []
 # bundle "libopus" instead of dynamic linking
 bundled = ["dep:cmake"]
+# disable runtime CPU feature detection
+no-runtime-feature-detection = []

--- a/bindgen.rustfmt.toml
+++ b/bindgen.rustfmt.toml
@@ -1,0 +1,1 @@
+# This is rustfmt configuration for the generated bindings

--- a/build.rs
+++ b/build.rs
@@ -139,7 +139,11 @@ fn build() {
                     .define("OPUS_ARM_MAY_HAVE_NEON", to_opt(DO_RUNTIME_DETECTION));
             }
             Ok("x86_64") | Ok("x86") => {
-                let [mut has_sse, mut has_sse2, mut has_sse41, mut has_avx2, mut has_fma] = [false; _];
+                let mut has_sse = false;
+                let mut has_sse2 = false;
+                let mut has_sse41 = false;
+                let mut has_avx2 = false;
+                let mut has_fma = false;
 
                 for feat in target_features.split(',').map(|s| s.trim()) {
                     match feat {

--- a/build.rs
+++ b/build.rs
@@ -121,6 +121,51 @@ fn build() {
         }
     }
 
+    fn configure_cpu_features(cmake: &mut cmake::Config) {
+        const DO_RUNTIME_DETECTION: bool = cfg!(not(feature = "no-runtime-feature-detection"));
+
+        let Ok(target_features) = std::env::var("CARGO_CFG_TARGET_FEATURE") else {
+            return;
+        };
+
+        match std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() {
+            Ok("aarch64") | Ok("arm") => {
+                // TODO: feature detection on other arm flags?
+                // OPUS_ARM_PRESUME_DOTPROD, OPUS_ARM_PRESUME_EDSP, OPUS_ARM_PRESUME_MEDIA
+                let has_neon = target_features.split(',').any(|s| s.trim() == "neon");
+
+                cmake
+                    .define("OPUS_ARM_PRESUME_NEON", to_opt(has_neon))
+                    .define("OPUS_ARM_MAY_HAVE_NEON", to_opt(DO_RUNTIME_DETECTION));
+            }
+            Ok("x86_64") | Ok("x86") => {
+                let [mut has_sse, mut has_sse2, mut has_sse41, mut has_avx2, mut has_fma] = [false; _];
+
+                for feat in target_features.split(',').map(|s| s.trim()) {
+                    match feat {
+                        "sse" => has_sse = true,
+                        "sse2" => has_sse2 = true,
+                        "sse4.1" => has_sse41 = true,
+                        "avx2" => has_avx2 = true,
+                        "fma" => has_fma = true,
+                        _ => {}
+                    }
+                }
+
+                cmake
+                    .define("OPUS_X86_PRESUME_SSE", to_opt(has_sse))
+                    .define("OPUS_X86_PRESUME_SSE2", to_opt(has_sse2))
+                    .define("OPUS_X86_PRESUME_SSE4_1", to_opt(has_sse41))
+                    .define("OPUS_X86_PRESUME_AVX2", to_opt(has_avx2 && has_fma))
+                    .define("OPUS_X86_MAY_HAVE_SSE", to_opt(DO_RUNTIME_DETECTION))
+                    .define("OPUS_X86_MAY_HAVE_SSE2", to_opt(DO_RUNTIME_DETECTION))
+                    .define("OPUS_X86_MAY_HAVE_SSE4_1", to_opt(DO_RUNTIME_DETECTION))
+                    .define("OPUS_X86_MAY_HAVE_AVX2", to_opt(DO_RUNTIME_DETECTION));
+            }
+            _ => {}
+        }
+    }
+
     let mut cmake = cmake::Config::new(CURRENT_DIR);
     let rust_lto = std::env::var("CARGO_ENCODED_RUSTFLAGS").is_ok_and(|opt| opt.contains("linker-plugin-lto"));
     if !rust_lto {
@@ -163,6 +208,8 @@ fn build() {
          .define("OPUS_FORTIFY_SOURCE", to_opt(cfg!(not(feature = "no-fortify-source"))))
          .define("OPUS_DISABLE_INTRINSICS", to_opt(cfg!(feature = "no-simd")))
          .define("OPUS_FIXED_POINT", to_opt(cfg!(feature = "fixed-point")));
+
+    configure_cpu_features(&mut cmake);
 
     if let Some((toolchain_file, abi)) = get_android_vars() {
         cmake.define("CMAKE_TOOLCHAIN_FILE", toolchain_file);

--- a/build.rs
+++ b/build.rs
@@ -141,27 +141,13 @@ fn build() {
     ;
 
     //Keep this up to date with Cargo.toml
-    if cfg!(feature = "dred") {
-        cmake.define("OPUS_DRED", "ON");
-    }
-    if cfg!(feature = "osce") {
-        cmake.define("OPUS_OSCE", "ON");
-    }
-    if cfg!(feature = "no-hardening") {
-        cmake.define("OPUS_HARDENING", "OFF");
-    }
-    if cfg!(feature = "no-stack-protector") {
-        cmake.define("OPUS_STACK_PROTECTOR", "OFF");
-    }
-    if cfg!(feature = "no-fortify-source") {
-        cmake.define("OPUS_FORTIFY_SOURCE", "OFF");
-    }
-    if cfg!(feature = "no-simd") {
-        cmake.define("OPUS_DISABLE_INTRINSICS", "ON");
-    }
-    if cfg!(feature = "fixed-point") {
-        cmake.define("OPUS_FIXED_POINT", "ON");
-    }
+    cmake.define("OPUS_DRED", to_opt(cfg!(feature = "dred")))
+         .define("OPUS_OSCE", to_opt(cfg!(feature = "osce")))
+         .define("OPUS_HARDENING", to_opt(cfg!(not(feature = "no-hardening"))))
+         .define("OPUS_STACK_PROTECTOR", to_opt(cfg!(not(feature = "no-stack-protector"))))
+         .define("OPUS_FORTIFY_SOURCE", to_opt(cfg!(not(feature = "no-fortify-source"))))
+         .define("OPUS_DISABLE_INTRINSICS", to_opt(cfg!(feature = "no-simd")))
+         .define("OPUS_FIXED_POINT", to_opt(cfg!(feature = "fixed-point")));
 
     if let Some((toolchain_file, abi)) = get_android_vars() {
         cmake.define("CMAKE_TOOLCHAIN_FILE", toolchain_file);

--- a/build.rs
+++ b/build.rs
@@ -94,7 +94,7 @@ fn build() {
     //Disable LTO if someone tries to force it (e.g. Arch makepkg)
     //This is necessary because cmake crate doesn't pass env variables at configure step, so we will
     //adjust both configure variables and general build env (just in case)
-    fn fix_build_env(cmake: &mut cmake::Config) {
+    fn remove_lto_options(cmake: &mut cmake::Config) {
         for (var, cmake_var) in [("CFLAGS", "CMAKE_C_FLAGS"), ("CXXFLAGS", "CMAKE_CXX_FLAGS")] {
             if let Ok(value) = std::env::var(var) {
                 if value.contains("-flto") {
@@ -112,8 +112,21 @@ fn build() {
         }
     }
 
+    //Converts bool to cmake's "ON/OFF"
+    fn to_opt(val: bool) -> &'static str {
+        if val {
+            "ON"
+        } else {
+            "OFF"
+        }
+    }
+
     let mut cmake = cmake::Config::new(CURRENT_DIR);
-    fix_build_env(&mut cmake);
+    let rust_lto = std::env::var("CARGO_ENCODED_RUSTFLAGS").is_ok_and(|opt| opt.contains("linker-plugin-lto"));
+    if !rust_lto {
+        remove_lto_options(&mut cmake);
+    }
+
     cmake.define("OPUS_INSTALL_PKG_CONFIG_MODULE", "OFF")
          .define("OPUS_INSTALL_CMAKE_CONFIG_MODULE", "OFF")
          //Defining these variables disable GNUInstallDirs so in addition to /lib
@@ -124,8 +137,8 @@ fn build() {
          .define("CMAKE_INSTALL_OLDINCLUDEDIR", "include")
          .define("CMAKE_INSTALL_LIBDIR", "lib")
          .define("CMAKE_TRY_COMPILE_TARGET_TYPE", "STATIC_LIBRARY")
-         //Ensure opus's CMake never enables LTO
-         .define("CMAKE_INTERPROCEDURAL_OPTIMIZATION", "off");
+         .define("CMAKE_INTERPROCEDURAL_OPTIMIZATION", to_opt(rust_lto))
+    ;
 
     //Keep this up to date with Cargo.toml
     if cfg!(feature = "dred") {

--- a/build.rs
+++ b/build.rs
@@ -30,7 +30,7 @@ fn generate_lib() {
     let out = path::PathBuf::new().join("src").join("lib.rs");
 
     let bindings = bindgen::Builder::default().header("src/wrapper.h")
-                                              .raw_line(PREPEND_LIB)
+                                              .raw_line(PREPEND_LIB.trim_ascii())
                                               .parse_callbacks(Box::new(ParseCallbacks))
                                               .generate_comments(false)
                                               .layout_tests(false)
@@ -39,6 +39,7 @@ fn generate_lib() {
                                               .allowlist_function("[oO]pus.+")
                                               .allowlist_var("[oO].+")
                                               .use_core()
+                                              .rustfmt_configuration_file(Some("bindgen.rustfmt.toml".into()))
                                               .generate()
                                               .expect("Unable to generate bindings");
 

--- a/build.rs
+++ b/build.rs
@@ -127,6 +127,12 @@ fn build() {
         remove_lto_options(&mut cmake);
     }
 
+    let opt_level = std::env::var("OPT_LEVEL");
+    let opt_level = opt_level.as_deref().unwrap_or_else(|err| {
+        println!("cargo:warning=OPT_LEVEL error: {err:?}, assuming release");
+        "3"
+    });
+
     cmake.define("OPUS_INSTALL_PKG_CONFIG_MODULE", "OFF")
          .define("OPUS_INSTALL_CMAKE_CONFIG_MODULE", "OFF")
          //Defining these variables disable GNUInstallDirs so in addition to /lib
@@ -138,7 +144,16 @@ fn build() {
          .define("CMAKE_INSTALL_LIBDIR", "lib")
          .define("CMAKE_TRY_COMPILE_TARGET_TYPE", "STATIC_LIBRARY")
          .define("CMAKE_INTERPROCEDURAL_OPTIMIZATION", to_opt(rust_lto))
-    ;
+         .define("CMAKE_BUILD_TYPE", match opt_level {
+             "s" | "z" => "MinSizeRel",
+             // Using release build even in debug to decrease the number of rebuilds
+             // Standard CMAKE_BUILD_TYPEs: "Release", "MinSizeRel", "RelWithDebInfo", "Debug"
+             "0" | "1" | "2" | "3" => "Release",
+             other => {
+                 println!("cargo:warning=unexpected OPT_LEVEL='{other}', assuming release");
+                 "Release"
+             }
+         });
 
     //Keep this up to date with Cargo.toml
     cmake.define("OPUS_DRED", to_opt(cfg!(feature = "dred")))

--- a/build.rs
+++ b/build.rs
@@ -124,9 +124,10 @@ fn build() {
     fn configure_cpu_features(cmake: &mut cmake::Config) {
         const DO_RUNTIME_DETECTION: bool = cfg!(not(feature = "no-runtime-feature-detection"));
 
-        let Ok(target_features) = std::env::var("CARGO_CFG_TARGET_FEATURE") else {
-            return;
-        };
+        let target_features = std::env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_else(|err| {
+            println!("cargo:warning=failed to get CARGO_CFG_TARGET_FEATURE: {err:?}. Assuming no features are guaranteed");
+            String::new()
+        });
 
         match std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() {
             Ok("aarch64") | Ok("arm") => {
@@ -165,6 +166,9 @@ fn build() {
                     .define("OPUS_X86_MAY_HAVE_SSE2", to_opt(DO_RUNTIME_DETECTION))
                     .define("OPUS_X86_MAY_HAVE_SSE4_1", to_opt(DO_RUNTIME_DETECTION))
                     .define("OPUS_X86_MAY_HAVE_AVX2", to_opt(DO_RUNTIME_DETECTION));
+            }
+            Err(err) => {
+                println!("cargo:warning=failed to get CARGO_CFG_TARGET_ARCH: {err:?}. CPU feature configuration is left up to CMake");
             }
             _ => {}
         }


### PR DESCRIPTION
Messed around with opus for my project and came up with a few improvements to this library. Can break the PR up if you would want to accept the changes partially.

* Re-enable rustfmt for bindings
  "disable_all_formatting = true" in `.rustfmt.toml` applies to the formatting done on `lib.rs` during `bindgen`, and it looks like a one-line mess. Specify empty `rustfmt` config to be applied to the generated file so it is formatted normally and trim the `PREPEND_LIB` to make newly-generated `lib.rs` identical to the current one.

* Allow cross-language LTO
  Now we detect if the library is compiled with cross-language LTO (using [linker-plugin-lto](https://doc.rust-lang.org/rustc/linker-plugin-lto.html)) and pass it onward to cmake. If linker-plugin-lto is not used - keeps behavior as-is. I've checked, and this is actually working, for example a call to `opus_encoder_get_size(2)` is replaced with a constant in the final binary.

* Explicitly control opus options
  Always set feature-controlled options as either "ON" or "OFF", do not rely on defaults of the opus.

* Set CMAKE_BUILD_TYPE from OPT_LEVEL
  Explicitly set CMAKE_BUILD_TYPE to "Release", except when built with rust opt level "s" or "z", then "MinSizeRel". I tried setting it to "Debug" when OPT_LEVEL="0", but this causes more rebuilds and doesn't make the builds much faster.

* CPU feature detection from `TARGET_FEATURE`s
  Pass `TARGET_FEATURE`s from rust to cmake, allowing the user to control guaranteed CPU features using standard rust methods (like `target-cpu`). Also added "no-runtime-feature-detection" feature to disable runtime feature detection in opus.

  