### PR TITLE
Fix OSCE bandwidth extension on bundled builds

### DIFF
--- a/opus.patch
+++ b/opus.patch
@@ -1,5 +1,5 @@
 diff --git a/opus/CMakeLists.txt b/opus/CMakeLists.txt
-index fcf034b..c574533 100644
+index fcf034b..afef617 100644
 --- a/opus/CMakeLists.txt
 +++ b/opus/CMakeLists.txt
 @@ -281,9 +281,17 @@ endif()
@@ -22,3 +22,12 @@ index fcf034b..c574533 100644
    endif()
  endif()
  
+@@ -423,7 +431,7 @@ endif()
+ 
+ if (OPUS_OSCE)
+   add_sources_group(opus lpcnet ${osce_headers} ${osce_sources})
+-  target_compile_definitions(opus PRIVATE ENABLE_OSCE)
++  target_compile_definitions(opus PRIVATE ENABLE_OSCE ENABLE_OSCE_BWE)
+ endif()
+ 
+ if(NOT OPUS_DISABLE_INTRINSICS)

--- a/opus/CMakeLists.txt
+++ b/opus/CMakeLists.txt
@@ -431,7 +431,7 @@ endif()
 
 if (OPUS_OSCE)
   add_sources_group(opus lpcnet ${osce_headers} ${osce_sources})
-  target_compile_definitions(opus PRIVATE ENABLE_OSCE)
+  target_compile_definitions(opus PRIVATE ENABLE_OSCE ENABLE_OSCE_BWE)
 endif()
 
 if(NOT OPUS_DISABLE_INTRINSICS)


### PR DESCRIPTION
Applying the fix from opus `main` (https://gitlab.xiph.org/xiph/opus/-/commit/475cbc5d):
> This fixes compilation of the bandwidth extension module when compiling
> with cmake. Matches the behaviour of --enable-osce via configure.ac.
>
> Signed-off-by: [Jean-Marc Valin](mailto:jmvalin@jmvalin.ca) <[jmvalin@jmvalin.ca](mailto:jmvalin@jmvalin.ca)>

Currently `OPUS_SET_OSCE_BWE_REQUEST` returns `OPUS_UNIMPLEMENTED` on `bundled` `osce` builds, after this patch it works as expected.